### PR TITLE
[Feature] Handle query_cache_type the same as read-only when server h…

### DIFF
--- a/_states/percona.py
+++ b/_states/percona.py
@@ -55,10 +55,16 @@ def setglobal(name, value, fail_on_missing=True, fail_on_readonly=True, **connec
 
     try:
         result = __salt__['percona.setglobal'](name, value, fail_on_readonly=False, **connection_args)
-        if not result:
+        if result == 'readonly':
             ret['comment'] = 'Variable %s is read-only' % name
             ret['changes'] = {}
             ret['result'] = False if fail_on_readonly else None
+        elif result == 'query_cache_type':
+            ret['comment'] = 'Variable %s cannot be enabled dynamically if server has been started with disabled Query Cache' % name
+            ret['changes'] = {}
+            ret['result'] = False if fail_on_readonly else None
+        elif not result:
+            ret['result'] = False
         else:
             ret['result'] = True
     except Exception as e:


### PR DESCRIPTION
…as been started without Query Cache

When the MySQL server has been started with query_cache_type=0,
it cannot be enabled dynamically, making it a de-facto read-only
variable. MySQL uses a different error message and code for this
case.