### PR TITLE
Create tmpdir if it does not exist

### DIFF
--- a/percona/config.sls
+++ b/percona/config.sls
@@ -46,6 +46,14 @@ mysql_python_dep:
 {% endif %}
 
 {% for global, value in global_params.iteritems() %}
+
+{% if 'tmpdir' in global %}
+{{ value }}:
+  file.directory:
+    - mode: 1777
+    - makedirs: True
+{% endif %}
+
 {{ global }}:
   percona.setglobal:
     - value: {{ value }}


### PR DESCRIPTION
If 'tmpdir' is given in pillar, make sure that it exists.
MySQL refuses to start if the directory does not exist