### PR TITLE
Add a require for python-mysqldb to mysql user creation

### DIFF
--- a/percona/server.sls
+++ b/percona/server.sls
@@ -72,6 +72,7 @@ mysql_user_{{ name }}_{{ user['host'] }}:
     - password: {{ user['password'] }}
     - connection_pass: {{ percona_settings.get('root_password', '') }}
     - require:
+      - pkg: mysql_python_dep
       - service: percona_svc
 {%   if os_family in ['RedHat', 'Suse'] %}
       - mysql_user: mysql_root_password


### PR DESCRIPTION
Missed this requirement, thinking it'd be pulled in by the service requirement. Apparently, it is not, so we specify it explicitly.

(disregard the branch name)