### PR TITLE
[Fix] saltstack changed type of result on error

### DIFF
--- a/_modules/percona.py
+++ b/_modules/percona.py
@@ -29,7 +29,7 @@ def setglobal(name, value, fail_on_readonly=True, **connection_args):
 
 
     result = __salt__['mysql.query']('mysql', query, **connection_args)
-    if len(result) == 0 and 'mysql.error' in __context__:
+    if ( ( isinstance(result, bool) and result == False ) or ( isinstance(result, dict) and len(result) == 0 ) ) and 'mysql.error' in __context__:
         err = __context__['mysql.error']
         del(__context__['mysql.error'])
         is_readonly = '1238' in err


### PR DESCRIPTION
Commit 5941a7c5be67a4e28401c86d1aa48860b1ca8c8f changed the type of
result to bool in case of an error. This results in the following error

     Comment: object of type 'bool' has no len()

The commit was merged in v2017.5

This fixes the module to cope with both types

commit 5941a7c5be67a4e28401c86d1aa48860b1ca8c8f
Author: Christian McHugh <McHughC@DNB.com>
Date:   Wed Jan 4 17:55:40 2017 +0000

    Modify mysql module to return False on failure
    Add file hanlding to mysql module
    Add file hanlding to mysql state

diff --git a/salt/modules/mysql.py b/salt/modules/mysql.py
index 900bcb0..0cbd3b8 100644
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -647,7 +647,7 @@ def query(database, query, **connection_args):
         err = 'MySQL Error {0}: {1}'.format(*exc)
         __context__['mysql.error'] = err
         log.error(err)
-        return {}
+        return False
     results = cur.fetchall()
     elapsed = (time.time() - start)
     if elapsed < 0.200:
