### PR TITLE
Make setting root password possible for percona 5.6

### DIFF
--- a/percona/map.jinja
+++ b/percona/map.jinja
@@ -61,9 +61,20 @@
     merge=True)
 %}
 
+{## Bug in percona 5.6 needs " in root password to be escaped. See https://jira.percona.com/browse/PS-4572 ##}
+{% if percona_settings.root_password %}
+{%   if percona_settings.version|string|trim == '5.6' %}
+{%     set debconf_password_entry = percona_settings.root_password|replace('"', '\\"') %}
+{%   else %}
+{%     set debconf_password_entry = percona_settings.root_password %}
+{%   endif %}
+{%   do percona_settings.update({ 'debconf_password_entry': debconf_password_entry }) %}
+{% endif %}
+
 {% if grains.os_family == 'RedHat' %}
 {%   set versionstring = percona_settings.version | replace('.','') %}
 {% else %}
 {%   set versionstring = percona_settings.version %}
 {% endif %}
 {% do percona_settings.update({ 'versionstring': versionstring }) %}
+

--- a/percona/server.sls
+++ b/percona/server.sls
@@ -25,9 +25,11 @@ mysql_debconf:
   debconf.set:
     - name: {{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}
     - data:
-        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/root-pass': {'type': 'password', 'value': '{{ percona_settings.root_password }}'}
-        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/re-root-pass': {'type': 'password', 'value': '{{ percona_settings.root_password }}'}
+        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/root-pass': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
+        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/re-root-pass': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
         '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
+        '{{ percona_settings.server_pkg }}/root_password': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
+        '{{ percona_settings.server_pkg }}/root_password_again': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
     - require_in:
       - pkg: percona_server
     - require:


### PR DESCRIPTION
 - The 5.6 package uses a different schema for the debconf entry
 - The 5.6 package needs double quotation marks to be escaped (https://jira.percona.com/browse/PS-4572)