### PR TITLE
[Feature] Add pillar to optionally hold server pkg

### DIFF
--- a/percona/defaults.yaml
+++ b/percona/defaults.yaml
@@ -7,3 +7,4 @@ mysql:
   reload_on_change: False
   datadir: /var/lib/mysql
   install_motd: True
+  hold_server_pkg: False

--- a/percona/server.sls
+++ b/percona/server.sls
@@ -50,6 +50,7 @@ mysql_root_password:
 percona_server:
   pkg.installed:
     - name: {{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}
+    - hold: {{ percona_settings.hold_server_pkg }}
     - require:
 {% for r in repolist %}
       - pkgrepo: {{ r }}

--- a/pillar.example
+++ b/pillar.example
@@ -12,6 +12,7 @@ mysql:
       key_url: salt://percona/files/my-keyring.gpg
   root_password: <password>
   reload_on_change: True
+  hold_server_pkg: True #hold the installed version of percona-server (prevents automatic restarts on upgrade)
   datadir: /var/lib/mysql
   config_directory: #there is a default for every distribution but you can overvrite if you want to
   install_motd: True #print mysqld version as part of motd. Ubuntu only at the moment


### PR DESCRIPTION
This commit introduces the boolean pillar "mysql:hold_server_pkg" which
toggles wether the installed server package is set to hold.