### PR TITLE
[WIP][Refactor] Separate installation and start/config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,19 +21,27 @@ Available states
 ``percona.server``
 -------
 
-Install and start percona-server. Includes percona.config, percona.client and percona.repo.
+Install and start percona-server. Includes percona.config and percona.install.
 
 ``percona.client``
 -------
 
-Install the client. Includes percona.config and percona.repo.
+Install the client. Includes percona.config-files and percona.repo.
+
+``percona.install``
+-------
+
+Install percona-server and enable it. Includes percona.config-files, percona.client and percona.repo.
+
+``percona.config-files``
+-------
+
+If pillar "mysql.config.<filename>" is set, manage those.
 
 ``percona.config``
 -------
 
-If pillar "mysql.config.<filename>" is set, manage those. Server will not be
-restarted by default, set pillar "mysql.restart_on_change: True" for
-autorestart on config change.
+Includes percona.config-files and adds autorestart on config change if pillar "mysql.restart_on_change: True" is set. Additionally changes dynamic configuration at runtime.
 
 ``percona.repo``
 -------

--- a/percona/client.sls
+++ b/percona/client.sls
@@ -2,7 +2,7 @@
 
 include:
   - .repo
-  - .config
+  - .config-files
 
 percona_client:
   pkg.installed:

--- a/percona/config-files.sls
+++ b/percona/config-files.sls
@@ -1,0 +1,34 @@
+{% from "percona/map.jinja" import percona_settings with context %}
+
+include:
+  - .install
+
+{{ percona_settings.config_directory }}:
+  file.directory:
+    - makedirs: True
+    - user: root
+    - group: root
+
+{% if 'config' in percona_settings and percona_settings.config is mapping %}
+{%   for file, content in percona_settings.config|dictsort %}
+{%     if file == 'my.cnf' %}
+{%       set filepath = percona_settings.my_cnf_path %}
+{%     else %}
+{%       set filepath = percona_settings.config_directory + '/' + file %}
+{%     endif %}
+{{ filepath }}:
+  file.managed:
+    - user: root
+    - group: root
+    - mode: 0644
+    - source: salt://percona/files/mysql.cnf.j2
+    - template: jinja
+    - context:
+        config: {{ content |default({}) }}
+    - require_in:
+      - pkg: percona_client
+      - pkg: percona_server
+    - require:
+      - file: {{ percona_settings.config_directory }}
+{%   endfor %}
+{% endif %}

--- a/percona/install.sls
+++ b/percona/install.sls
@@ -1,0 +1,71 @@
+{% from "percona/map.jinja" import percona_settings with context %}
+{% set os_family = salt['grains.get']('os_family') %}
+{% set initsystem = salt['grains.get']('init') %}
+{% set repolist = [] %}
+{% if 'repos' in percona_settings and percona_settings.repos is list %}
+{%   for repo in percona_settings.repos if repo is mapping and 'name' in repo %}
+{% do repolist.append("perconarepo_" + loop.index|string) %}
+{%   endfor %}
+{% endif %}
+
+include:
+  - .repo
+  - .client
+  - .config-files
+  - .motd
+
+{% if percona_settings.get('root_password', False) %}
+{% if os_family == 'Debian' %}
+percona_debconf_utils:
+  pkg.installed:
+    - name: {{ percona_settings.debconf_utils }}
+
+mysql_debconf:
+  debconf.set:
+    - name: {{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}
+    - data:
+        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/root-pass': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
+        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/re-root-pass': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
+        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
+        '{{ percona_settings.server_pkg }}/root_password': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
+        '{{ percona_settings.server_pkg }}/root_password_again': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
+    - require_in:
+      - pkg: percona_server
+    - require:
+      - pkg: percona_debconf_utils
+{% endif %}
+{% endif %}
+
+percona_server:
+  pkg.installed:
+    - name: {{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}
+    - require:
+{% for r in repolist %}
+      - pkgrepo: {{ r }}
+{% endfor %}
+
+percona_server_enabled:
+  service.enabled:
+    - name: {{ percona_settings.server_svc }}
+    - require:
+      - pkg: percona_server
+
+{% if initsystem == 'systemd' %}
+percona_remove_limits:
+  file.managed:
+    - name: /etc/systemd/system/mysql.service.d/override.conf
+    - makedirs: True
+    - user: root
+    - group: root
+    - mode: 644
+    - contents: |
+        [Service]
+        LimitNOFILE=infinity
+        LimitMEMLOCK=infinity
+    - require_in:
+      - pkg: percona_server
+  module.run:
+    - name: service.systemctl_reload
+    - onchanges:
+      - file: /etc/systemd/system/mysql.service.d/override.conf
+{% endif %}

--- a/percona/server.sls
+++ b/percona/server.sls
@@ -1,40 +1,14 @@
 {% from "percona/map.jinja" import percona_settings with context %}
 {% set os_family = salt['grains.get']('os_family') %}
 {% set initsystem = salt['grains.get']('init') %}
-{% set repolist = [] %}
-{% if 'repos' in percona_settings and percona_settings.repos is list %}
-{%   for repo in percona_settings.repos if repo is mapping and 'name' in repo %}
-{% do repolist.append("perconarepo_" + loop.index|string) %}
-{%   endfor %}
-{% endif %}
 
 include:
-  - .repo
-  - .client
+  - .install
   - .config
   - .service
-  - .motd
 
 {% if percona_settings.get('root_password', False) %}
-{% if os_family == 'Debian' %}
-percona_debconf_utils:
-  pkg.installed:
-    - name: {{ percona_settings.debconf_utils }}
-
-mysql_debconf:
-  debconf.set:
-    - name: {{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}
-    - data:
-        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/root-pass': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
-        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/re-root-pass': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
-        '{{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}/start_on_boot': {'type': 'boolean', 'value': 'true'}
-        '{{ percona_settings.server_pkg }}/root_password': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
-        '{{ percona_settings.server_pkg }}/root_password_again': {'type': 'password', 'value': '{{ percona_settings.debconf_password_entry }}'}
-    - require_in:
-      - pkg: percona_server
-    - require:
-      - pkg: percona_debconf_utils
-{% elif os_family in ['RedHat', 'Suse'] %}
+{%   if os_family in ['RedHat', 'Suse'] %}
 mysql_root_password:
   mysql_user.present:
     - name: root
@@ -44,16 +18,8 @@ mysql_root_password:
     - require:
       - service: percona_svc
       - pkg: mysql_python_dep
+{%   endif %}
 {% endif %}
-{% endif %}
-
-percona_server:
-  pkg.installed:
-    - name: {{ percona_settings.server_pkg }}-{{ percona_settings.versionstring }}
-    - require:
-{% for r in repolist %}
-      - pkgrepo: {{ r }}
-{% endfor %}
 
 {% if os_family in ['RedHat', 'Suse'] and percona_settings.version >= 5.7 %}
 # Initialize mysql database with --initialize-insecure option before starting service so we don't get locked out.
@@ -97,25 +63,11 @@ mysql_grant_{{ name }}_{{ user['host'] }}_{{ loop.index0 }}:
 {% endfor %}
 
 {% if initsystem == 'systemd' %}
-percona_remove_limits:
-  file.managed:
-    - name: /etc/systemd/system/mysql.service.d/override.conf
-    - makedirs: True
-    - user: root
-    - group: root
-    - mode: 644
-    - contents: |
-        [Service]
-        LimitNOFILE=infinity
-        LimitMEMLOCK=infinity
-    - require_in:
-      - pkg: percona_server
-  module.run:
-    - name: service.systemctl_reload
-    - onchanges:
-      - file: /etc/systemd/system/mysql.service.d/override.conf
 {%   if percona_settings.reload_on_change %}
-    - watch_in:
-      - service: percona_svc
+extend:
+  percona_remove_limits:
+    module:
+      - watch_in:
+        - service: percona_svc
 {%   endif %}
 {% endif %}


### PR DESCRIPTION
This commit introduces "percona/install.sls".
It allows installation of percona-server and
management of configuration files without the
need to have a running instance.
It is the intention of this commit to not change the
current API of percona-formula.